### PR TITLE
Add package-manager-friendly install targets and tunable variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 
-# Use ?= to allow overriding from env or command-line
+# Use ?= to allow overriding from the env or command-line, e.g.
+#
+#       make CXXFLAGS="-O3 -fPIC" install
+#
+# Package managers will override many of these variables automatically, so
+# this is aimed at making it easy to create packages (Debian packages,
+# FreeBSD ports, MacPorts, pkgsrc, etc.)
+
 CC ?=		cc
 CFLAGS ?=	-O -g
 AR ?=		ar

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ CFLAGS ?=	-O -g
 AR ?=		ar
 MKDIR ?=	mkdir
 INSTALL ?=	install -c
+STRIP ?=	strip
 DESTDIR ?=	stage
 PREFIX ?=	/usr/local
 
@@ -28,7 +29,7 @@ install: all
 	${INSTALL} ${LIB} ${DESTDIR}${PREFIX}/lib
 
 install-strip: install
-	${STRIP_CMD} ${DESTDIR}${PREFIX}/bin/${BIN}
+	${STRIP} ${DESTDIR}${PREFIX}/bin/${BIN}
 
 clean:
 	rm -rf ${BIN} ${LIB} ${OBJS} ${MAIN} ${DESTDIR}

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,37 @@
 
-CC ?=		gcc
-CFLAGS ?=
+# Use ?= to allow overriding from env or command-line
+CC ?=		cc
+CFLAGS ?=	-O -g
+AR ?=		ar
+MKDIR ?=	mkdir
+INSTALL ?=	install -c
+DESTDIR ?=	stage
+PREFIX ?=	/usr/local
 
-OBJS=	main.o filevercmp.o
+OBJS=	filevercmp.o
+MAIN =	main.o
+BIN =	filevercmp
+LIB =	libfilevercmp.a
 
-all: filevercmp
+all: ${BIN} ${LIB}
+
+${BIN}: ${OBJS} ${MAIN}
+	${CC} ${CFLAGS} -o ${BIN} ${OBJS} ${MAIN}
+
+${LIB}: ${OBJS}
+	${AR} -rs ${LIB} ${OBJS}
+
+install: all
+	${MKDIR} -p ${DESTDIR}${PREFIX}/bin
+	${MKDIR} -p ${DESTDIR}${PREFIX}/lib
+	${INSTALL} ${BIN} ${DESTDIR}${PREFIX}/bin
+	${INSTALL} ${LIB} ${DESTDIR}${PREFIX}/lib
+
+install-strip: install
+	${STRIP_CMD} ${DESTDIR}${PREFIX}/bin/${BIN}
 
 clean:
-	rm -f filevercmp ${OBJS}
+	rm -rf ${BIN} ${LIB} ${OBJS} ${MAIN} ${DESTDIR}
 
 .PHONY: all clean
 
@@ -16,6 +40,3 @@ filevercmp.o: filevercmp.c filevercmp.h
 
 main.o: main.c filevercmp.h
 	${CC} ${CFLAGS} -c main.c
-
-filevercmp: ${OBJS}
-	${CC} ${CFLAGS} -o filevercmp ${OBJS}

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,10 @@ ${LIB}: ${OBJS}
 
 install: all
 	${MKDIR} -p ${DESTDIR}${PREFIX}/bin
+	${MKDIR} -p ${DESTDIR}${PREFIX}/include
 	${MKDIR} -p ${DESTDIR}${PREFIX}/lib
 	${INSTALL} ${BIN} ${DESTDIR}${PREFIX}/bin
+	${INSTALL} *.h ${DESTDIR}${PREFIX}/include
 	${INSTALL} ${LIB} ${DESTDIR}${PREFIX}/lib
 
 install-strip: install


### PR DESCRIPTION
Tested both separate build and integrated build under vcflib on my end, but I recommend retesting on your platform following each pull just to be sure.
